### PR TITLE
Add post-gen install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ be merged into the generated `package.json`:
 ```ts
 export default {
   projectName: 'my-app',
+  packageManager: 'pnpm',
   tools: { eslint: true, prettier: true },
   dependencies: {
     devDependencies: {
@@ -32,6 +33,9 @@ export default {
   },
 };
 ```
+
+dmpak runs the configured package manager after `init` and `update` to install dependencies. If
+`packageManager` is omitted, `pnpm` is used by default.
 
 # Usage
 <!-- usage -->

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -54,7 +54,7 @@ export default class Init extends Command {
     const generator = new ProjectGenerator({ ...config, isInit: true });
     await generator.generateAll();
 
-    await runInstall(config.packageManager);
+    await runInstall(config.packageManager ?? 'pnpm');
 
     this.log('🎉 Project initialized successfully!');
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,6 +5,7 @@ import { basename, resolve } from 'node:path';
 
 import { loadDmpakConfig } from '../config/load-config.js';
 import { ProjectGenerator } from '../projects/project-generator.js';
+import { runInstall } from '../utils/package-manager.js';
 
 /**
  * Initialize a new project by creating a configuration file and generating
@@ -52,6 +53,8 @@ export default class Init extends Command {
     const config = await loadDmpakConfig();
     const generator = new ProjectGenerator({ ...config, isInit: true });
     await generator.generateAll();
+
+    await runInstall(config.packageManager);
 
     this.log('🎉 Project initialized successfully!');
   }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -22,7 +22,7 @@ export default class Dmpak extends Command {
     const generator = new ProjectGenerator({ ...config, isInit: false });
     await generator.generateAll();
 
-    await runInstall(config.packageManager);
+    await runInstall(config.packageManager ?? 'pnpm');
 
     this.log('🎉 Project updated successfully!');
   }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -2,6 +2,7 @@ import { Command } from '@oclif/core';
 
 import { loadDmpakConfig } from '../config/load-config.js';
 import { ProjectGenerator } from '../projects/project-generator.js';
+import { runInstall } from '../utils/package-manager.js';
 
 /**
  * Default command which regenerates all project files according to the
@@ -20,6 +21,8 @@ export default class Dmpak extends Command {
 
     const generator = new ProjectGenerator({ ...config, isInit: false });
     await generator.generateAll();
+
+    await runInstall(config.packageManager);
 
     this.log('🎉 Project updated successfully!');
   }

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -18,6 +18,7 @@ export const dmpakConfigSchema = z.object({
       peerDependencies: z.record(z.string(), z.string()).optional(),
     })
     .optional(),
+  packageManager: z.enum(['pnpm', 'npm', 'yarn']).optional(),
   projectAuthor: z.string().optional(),
   projectDescription: z.string().optional(),
   projectHomepage: z.string().optional(),
@@ -78,7 +79,9 @@ export async function loadDmpakConfig(
       );
     }
 
-    return parseResult.data;
+    const cfg = parseResult.data;
+    if (!cfg.packageManager) cfg.packageManager = 'pnpm';
+    return cfg;
   }
 
   throw new Error(`No dmpak config found in ${cwd}`);

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -1,0 +1,17 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Install dependencies using the specified package manager.
+ *
+ * @param packageManager - Command like 'pnpm', 'npm', or 'yarn'
+ */
+export async function runInstall(packageManager: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(packageManager, ['install'], { stdio: 'inherit' });
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${packageManager} install failed with exit code ${code}`));
+    });
+    proc.on('error', reject);
+  });
+}


### PR DESCRIPTION
## Summary
- run package manager install after generating project files
- allow setting `packageManager` in the config
- document default package manager in README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68517f0e32c083219412115758f7f563