### PR TITLE
Fix scripts handling and improve config autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ A lightweight ESM-based CLI framework for bootstrapping and managing TypeScript 
 # Configuration
 
 dmpak reads configuration from `.dmpakrc.*` or `.dmpakts.ts` in the project
-root. Besides enabling tools you can declare additional dependencies which will
-be merged into the generated `package.json`:
+root. Using a TypeScript config file (`.dmpakrc.ts` or `.dmpakts.ts`) enables
+editor autocompletion when you import the `DmpakConfig` type:
 
 ```ts
-export default {
+import type { DmpakConfig } from 'dmpak';
+
+const config: DmpakConfig = {
   projectName: 'my-app',
   packageManager: 'pnpm',
   tools: { eslint: true, prettier: true },
@@ -32,7 +34,12 @@ export default {
     },
   },
 };
+
+export default config;
 ```
+
+Besides enabling tools you can declare additional dependencies which will be
+merged into the generated `package.json`:
 
 dmpak runs the configured package manager after `init` and `update` to install dependencies. If
 `packageManager` is omitted, `pnpm` is used by default.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dmpak",
   "description": "A lightweight ESM-based CLI framework for bootstrapping and managing TypeScript project configurations with CI/CD support.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Yannick Tresch @yanu23",
   "bin": {
     "dmpak": "./bin/run.js"

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -32,23 +32,27 @@ export default class Init extends Command {
    */
   async run(): Promise<void> {
     const { flags } = await this.parse(Init);
-    const file = resolve(process.cwd(), '.dmpakrc.mjs');
+    const file = resolve(process.cwd(), '.dmpakrc.ts');
 
     if (existsSync(file) && !flags.force) {
-      this.error('.dmpakrc.mjs already exists. Use --force to overwrite.');
+      this.error('.dmpakrc.ts already exists. Use --force to overwrite.');
       return;
     }
 
     const name = basename(process.cwd());
-    const content = `export default {
+    const content = `import type { DmpakConfig } from 'dmpak';
+
+const config: DmpakConfig = {
   projectName: '${name}',
   projectType: '${flags.type}',
   tools: { eslint: true, prettier: true },
 };
+
+export default config;
 `;
 
     await writeFile(file, content, 'utf8');
-    this.log('✅ Created .dmpakrc.mjs');
+    this.log('✅ Created .dmpakrc.ts');
 
     const config = await loadDmpakConfig();
     const generator = new ProjectGenerator({ ...config, isInit: true });

--- a/src/generators/package-json/package-json-generator.ts
+++ b/src/generators/package-json/package-json-generator.ts
@@ -47,7 +47,7 @@ export class PackageJsonGenerator extends ToolGenerator {
    */
   async generate(config: GeneratorConfig): Promise<void> {
     const base = getBaseFields(config);
-    const scripts = (config.scripts ?? {}) as Record<string, string>;
+    const scripts = { ...this.scripts, ...config.scripts } as Record<string, string>;
     const exports = getExportFields(config);
     const extraDeps = (config.dependencies ?? {}) as Record<
       string,

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -6,12 +6,22 @@ import { spawn } from 'node:child_process';
  * @param packageManager - Command like 'pnpm', 'npm', or 'yarn'
  */
 export async function runInstall(packageManager: string): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const proc = spawn(packageManager, ['install'], { stdio: 'inherit' });
-    proc.on('close', (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`${packageManager} install failed with exit code ${code}`));
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const proc = spawn(packageManager, ['install'], { stdio: 'inherit' });
+      proc.on('close', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`${packageManager} install failed with exit code ${code}`));
+      });
+      proc.on('error', reject);
     });
-    proc.on('error', reject);
-  });
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `${packageManager} is not installed. Install it or set packageManager in your config.`
+      );
+    }
+
+    throw error instanceof Error ? error : new Error(String(error));
+  }
 }

--- a/test/generators/package-json-generator.test.ts
+++ b/test/generators/package-json-generator.test.ts
@@ -77,4 +77,22 @@ describe('PackageJsonGenerator', () => {
     expect(raw).to.not.have.property('keywords');
     expect(raw).to.not.have.property('repository');
   });
+
+  it('merges scripts from config and generators', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'dmpak-pkg-'));
+    const pkg = new PackageJsonGenerator(dir);
+    pkg.addScript('build', 'tsc');
+
+    const config: GeneratorConfig = {
+      projectName: 'demo',
+      projectType: 'ts-lib',
+      scripts: { test: 'jest' },
+      tools: {},
+    };
+
+    await pkg.generate(config);
+
+    const raw = JSON.parse(await fs.readFile(join(dir, 'package.json'), 'utf8'));
+    expect(raw.scripts).to.deep.equal({ build: 'tsc', test: 'jest' });
+  });
 });


### PR DESCRIPTION
## Summary
- merge collected scripts into package.json
- generate `.dmpakrc.ts` with typings for better editor support
- improve error when package manager is missing
- document typed config in README
- test script merging in PackageJsonGenerator

## Testing
- `pnpm install`
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68518c4a9e348321a5bfc69841fe6fdb