### PR TITLE
Fix ts config loading on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dmpak",
   "description": "A lightweight ESM-based CLI framework for bootstrapping and managing TypeScript project configurations with CI/CD support.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Yannick Tresch @yanu23",
   "bin": {
     "dmpak": "./bin/run.js"

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -73,8 +73,10 @@ export async function loadDmpakConfig(
 
         // eslint-disable-next-line no-await-in-loop
         const { tsImport } = await import('tsx/esm/api');
+        const specifier =
+          process.platform === 'win32' ? fileUrl : path;
         // eslint-disable-next-line no-await-in-loop
-        const imported = await tsImport(path, import.meta.url);
+        const imported = await tsImport(specifier, import.meta.url);
         rawConfig = imported.default?.default ?? imported.default ?? imported;
       } else {
         // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
## Summary
- support Windows file URLs when loading ts config

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6851b3ba0d648321a6bf55a2c60edb95