### PR TITLE
Add CLI validation to workflows

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -1,12 +1,15 @@
-# test
 name: version, tag and github release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["tests"]
     branches: [main]
+    types:
+      - completed
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       actions: write
@@ -26,8 +29,7 @@ jobs:
           package_version=$(node -p "require('./package.json').version")
           exists=$(gh api repos/${{ github.repository }}/releases/tags/v$package_version >/dev/null 2>&1 && echo "true" || echo "")
 
-          if [ -n "$exists" ];
-          then
+          if [ -n "$exists" ]; then
             echo "Version v$package_version already exists"
             echo "::warning file=package.json,line=1::Version v$package_version already exists - no release will be created. If you want to create a new release, please update the version in package.json and push again."
             echo "skipped=true" >> $GITHUB_OUTPUT
@@ -36,7 +38,6 @@ jobs:
             echo "skipped=false" >> $GITHUB_OUTPUT
             echo "tag=v$package_version" >> $GITHUB_OUTPUT
           fi
-        # gh will automatically use the GITHUB_TOKEN provided by the workflow
       - name: Setup git
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,8 @@ jobs:
           run_install: false
       - run: pnpm install
       - run: pnpm run build
+      - name: Test dmpak init command
+        run: |
+          mkdir cli-test && cd cli-test
+          node ../bin/run.js init --type cdk-app
       - run: pnpm run test


### PR DESCRIPTION
## Summary
- trigger release after successful tests
- keep CLI validation in the test workflow only

## Testing
- `pnpm install`
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6852776c97fc8321bb2576e874c2c5ed